### PR TITLE
fix: Use correct string representation for mapped types as map keys

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "io.imotions.bson4k"
-version = "0.1-RC3"
+version = "0.1-RC4"
 
 val ktlint by configurations.creating
 

--- a/src/main/kotlin/io/imotions/bson4k/Bson.kt
+++ b/src/main/kotlin/io/imotions/bson4k/Bson.kt
@@ -73,7 +73,6 @@ class BsonBuilder internal constructor(conf: BsonConf) {
 }
 
 enum class BsonKind(val supportedKinds: List<PrimitiveKind>) {
-    PASS_THROUGH(emptyList()),
     DATE(listOf(PrimitiveKind.LONG, PrimitiveKind.STRING)),
     OBJECT_ID(listOf(PrimitiveKind.STRING)),
     UUID(listOf(PrimitiveKind.STRING))


### PR DESCRIPTION
A bug caused type mapping to affect how e.g. UUID values was encoded/decoded as map keys. The correct string representation is now used on encoding and on encoding type mapping is ignored for map keys.