### PR TITLE
Kotlin 1.5.21 and kotlinx.serialization 1.2.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,32 +15,31 @@
  */
 
 plugins {
-    kotlin("jvm") version "1.4.30"
-    kotlin("plugin.serialization") version "1.4.30"
+    kotlin("jvm") version "1.5.21"
+    kotlin("plugin.serialization") version "1.5.21"
     `maven-publish`
-    id("io.gitlab.arturbosch.detekt").version("1.16.0-RC1")
+    id("io.gitlab.arturbosch.detekt").version("1.17.0")
 }
 
 group = "io.imotions.bson4k"
-version = "0.1-RC6"
+version = "0.2-RC1"
 
 val ktlint by configurations.creating
 
 repositories {
-    jcenter()
     mavenCentral()
 }
 
 dependencies {
-    ktlint("com.pinterest:ktlint:0.40.0")
+    ktlint("com.pinterest:ktlint:0.42.1")
 
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:1.0.1")
-    implementation("org.mongodb:bson:4.2.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:1.2.2")
+    implementation("org.mongodb:bson:4.3.1")
 
-    testImplementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.0.1")
-    testImplementation("io.kotest:kotest-runner-junit5:4.4.1")
-    testImplementation("io.kotest:kotest-assertions-core:4.4.1")
-    testImplementation("io.kotest:kotest-property:4.4.1")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.2.2")
+    testImplementation("io.kotest:kotest-runner-junit5:4.6.1")
+    testImplementation("io.kotest:kotest-assertions-core:4.6.1")
+    testImplementation("io.kotest:kotest-property:4.6.1")
 }
 
 tasks.test {


### PR DESCRIPTION
Upgrade dependencies to ensure continued compatibility. Warrants a version bump to 0.2-RC1