### PR TITLE
Fix null decoding implementation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
 }
 
 group = "io.imotions.bson4k"
-version = "0.2-RC1"
+version = "0.2-RC2"
 
 val ktlint by configurations.creating
 

--- a/src/main/kotlin/io/imotions/bson4k/decoder/BsonDecoder.kt
+++ b/src/main/kotlin/io/imotions/bson4k/decoder/BsonDecoder.kt
@@ -146,7 +146,12 @@ class BsonDecoder(
     }
 
     override fun decodeNotNullMark(): Boolean {
-        return reader.currentBsonType != BsonType.NULL
+        return if (reader.currentBsonType == BsonType.NULL) {
+            reader.readNull()
+            false
+        } else {
+            true
+        }
     }
 
     override fun decodeBoolean(): Boolean = decodeBsonElement(reader::readBoolean, String::toBoolean)
@@ -167,10 +172,7 @@ class BsonDecoder(
     }
 
     override fun decodeNull(): Nothing? = decodeBsonElement(
-        {
-            reader.readNull()
-            null
-        },
+        { null },
         { null }
     )
 

--- a/src/test/kotlin/io/imotions/bson4k/common/Serialization.kt
+++ b/src/test/kotlin/io/imotions/bson4k/common/Serialization.kt
@@ -19,6 +19,8 @@ package io.imotions.bson4k.common
 import io.imotions.bson4k.Bson
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.builtins.nullable
+import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
@@ -77,4 +79,26 @@ object ObjectIdSerializer : KSerializer<ObjectId> {
 
     override fun serialize(encoder: Encoder, value: ObjectId) =
         encoder.encodeString(value.toHexString())
+}
+
+@ExperimentalSerializationApi
+object CustomNullableSerializer : KSerializer<String?> {
+    override fun deserialize(decoder: Decoder): String? {
+        if (decoder.decodeNotNullMark()) {
+            return decoder.decodeString()
+        } else {
+            // Return null vs decoder.decodeNull() should not matter
+            return null
+        }
+    }
+
+    override val descriptor: SerialDescriptor = String.serializer().nullable.descriptor
+
+    override fun serialize(encoder: Encoder, value: String?) {
+        if (value == null) {
+            encoder.encodeNull()
+        } else {
+            encoder.encodeString(value)
+        }
+    }
 }

--- a/src/test/kotlin/io/imotions/bson4k/common/Types.kt
+++ b/src/test/kotlin/io/imotions/bson4k/common/Types.kt
@@ -45,6 +45,12 @@ data class Wrapper<T>(val value: T)
 data class Wrapper2<A, B>(val x: A, val y: B)
 
 @Serializable
+data class Wrapper2Null<A, B>(val x: A? = null, val y: B?)
+
+@Serializable
+data class CustomNullables(val a: String? = null, @Serializable(CustomNullableSerializer::class) val b: String? = null)
+
+@Serializable
 data class MapWrapper<K, V>(val map: Map<K, V>)
 
 // Classes

--- a/src/test/kotlin/io/imotions/bson4k/decoder/BsonClassDecoderTest.kt
+++ b/src/test/kotlin/io/imotions/bson4k/decoder/BsonClassDecoderTest.kt
@@ -16,10 +16,7 @@
 
 package io.imotions.bson4k.decoder
 
-import io.imotions.bson4k.common.EnumClass
-import io.imotions.bson4k.common.Wrapper
-import io.imotions.bson4k.common.Wrapper2
-import io.imotions.bson4k.common.bson
+import io.imotions.bson4k.common.*
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import kotlinx.serialization.ExperimentalSerializationApi
@@ -52,5 +49,23 @@ class BsonClassDecoderTest : StringSpec({
         val doc = Document("x", "enum fields").append("y", "FOURTH")
         val wrapper = bson.decodeFromBsonDocument<Wrapper2<String, EnumClass>>(doc.toBsonDocument())
         wrapper shouldBe Wrapper2("enum fields", EnumClass.FOURTH)
+    }
+
+    "Decode class with nullables" {
+        val doc = Document("x", null).append("y", 42)
+        val wrapper = bson.decodeFromBsonDocument<Wrapper2<String?, Int?>>(doc.toBsonDocument())
+        wrapper shouldBe Wrapper2(null, 42)
+    }
+
+    "Decode class with nullable defaults present" {
+        val doc = Document("x", null).append("y", null)
+        val wrapper = bson.decodeFromBsonDocument<Wrapper2Null<String, String>>(doc.toBsonDocument())
+        wrapper shouldBe Wrapper2Null(y = null)
+    }
+
+    "Decode class with custom nullable serializer" {
+        val doc = Document("a", null).append("b", null)
+        val deserialized = bson.decodeFromBsonDocument<CustomNullables>(doc.toBsonDocument())
+        deserialized shouldBe CustomNullables(null)
     }
 })

--- a/src/test/kotlin/io/imotions/bson4k/encoder/BsonClassEncoderTest.kt
+++ b/src/test/kotlin/io/imotions/bson4k/encoder/BsonClassEncoderTest.kt
@@ -16,10 +16,7 @@
 
 package io.imotions.bson4k.encoder
 
-import io.imotions.bson4k.common.Class2
-import io.imotions.bson4k.common.Class3
-import io.imotions.bson4k.common.EnumClass
-import io.imotions.bson4k.common.bson
+import io.imotions.bson4k.common.*
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.ints.shouldBeExactly
@@ -80,5 +77,23 @@ class BsonClassEncoderTest : StringSpec({
             .also { println(it) }
 
         document["y"] shouldBe BsonString(EnumClass.THIRD.name)
+    }
+
+    "Encode class with all null values" {
+        val clazz = Wrapper2<Int?, Int?>(null, null)
+        val document = bson.encodeToBsonDocument(clazz)
+            .also { println(it) }
+
+        document["x"] shouldBe BsonNull()
+        document["y"] shouldBe BsonNull()
+    }
+
+    "Encode class with default nullables" {
+        val clazz = Wrapper2Null<String, String>(y = "hello")
+        val document = bson.encodeToBsonDocument(clazz)
+            .also { println(it) }
+
+        document["x"] shouldBe BsonNull()
+        document["y"] shouldBe BsonString("hello")
     }
 })


### PR DESCRIPTION
Closes #16 

The use of a custom serializer for a nullable string uncovered an edge case bug that leads to decoding errors caused by how the `decodeNull` and `decodeNotNullMarker` methods were implemented. This pr refactors these methods to mimic the behavior in the kotlinx serialization json format implementation, moving the responsibility for consuming the actual null value to the `decodeNotNullMarker` function