### PR TITLE
Structured map keys

### DIFF
--- a/src/main/kotlin/io/imotions/bson4k/Bson.kt
+++ b/src/main/kotlin/io/imotions/bson4k/Bson.kt
@@ -67,6 +67,7 @@ fun Bson(builderAction: BsonBuilder.() -> Unit): Bson {
 class BsonBuilder internal constructor(conf: BsonConf) {
     var classDiscriminator = conf.classDiscriminator
     var serializersModule = conf.serializersModule
+    var allowStructuredMapKeys = conf.allowStructuredMapKeys
     internal val bsonTypeMappings = conf.bsonTypeMappings.toMutableMap()
 
     fun addTypeMapping(serializer: KSerializer<*>, bsonKind: BsonKind) {
@@ -83,7 +84,8 @@ class BsonBuilder internal constructor(conf: BsonConf) {
         return BsonConf(
             classDiscriminator = classDiscriminator,
             serializersModule = serializersModule,
-            bsonTypeMappings = bsonTypeMappings
+            bsonTypeMappings = bsonTypeMappings,
+            allowStructuredMapKeys = allowStructuredMapKeys
         )
     }
 }

--- a/src/main/kotlin/io/imotions/bson4k/BsonConf.kt
+++ b/src/main/kotlin/io/imotions/bson4k/BsonConf.kt
@@ -28,5 +28,6 @@ typealias SerialName = String
 data class BsonConf internal constructor(
     val serializersModule: SerializersModule = EmptySerializersModule,
     val classDiscriminator: String = CLASS_DISCRIMINATOR,
-    val bsonTypeMappings: Map<SerialName, BsonKind> = emptyMap()
+    val bsonTypeMappings: Map<SerialName, BsonKind> = emptyMap(),
+    val allowStructuredMapKeys: Boolean = false
 )

--- a/src/main/kotlin/io/imotions/bson4k/common/BsonExceptions.kt
+++ b/src/main/kotlin/io/imotions/bson4k/common/BsonExceptions.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 iMotions A/S
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.imotions.bson4k.common
+
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.descriptors.SerialDescriptor
+
+internal const val allowStructuredMapKeysHint =
+    "Use 'allowStructuredMapKeys = true' in 'Json {}' builder to convert such maps to [key1, value1, key2, value2,...] arrays."
+
+sealed class BsonException(message: String) : SerializationException(message)
+
+class BsonEncodingException(message: String) : BsonException(message)
+
+fun invalidKeyKindException(keyDescriptor: SerialDescriptor) = BsonEncodingException(
+    "Value of type '${keyDescriptor.serialName}' cannot be used as a BSON map key. " +
+        "It should have either primitive or enum kind, but its kind is '${keyDescriptor.kind}'.\n" +
+        allowStructuredMapKeysHint
+)

--- a/src/main/kotlin/io/imotions/bson4k/common/BsonExceptions.kt
+++ b/src/main/kotlin/io/imotions/bson4k/common/BsonExceptions.kt
@@ -35,15 +35,16 @@ fun rootNotDocumentException() = BsonEncodingException(
         "containing other types. Hence primitives and arrays cannot be serialized without an enclosing type."
 )
 
-@OptIn(ExperimentalSerializationApi::class)
+@ExperimentalSerializationApi
 fun invalidKeyKindException(keyDescriptor: SerialDescriptor) = BsonEncodingException(
     "Value of type '${keyDescriptor.serialName}' cannot be used as a BSON map key. " +
         "It should have either primitive or enum kind, but its kind is '${keyDescriptor.kind}'.\n" +
         allowStructuredMapKeysHint
 )
 
-@OptIn(ExperimentalSerializationApi::class)
-fun missingClassDiscriminatorException(expectedDiscriminator: String, descriptor: SerialDescriptor) = BsonDecodingException(
-    "The expected class discriminator '$expectedDiscriminator', was not found when decoding the " +
-        "polymorphic type '${descriptor.serialName}'."
-)
+@ExperimentalSerializationApi
+fun missingClassDiscriminatorException(expectedDiscriminator: String, descriptor: SerialDescriptor) =
+    BsonDecodingException(
+        "The expected class discriminator '$expectedDiscriminator', was not found when decoding the " +
+            "polymorphic type '${descriptor.serialName}'."
+    )

--- a/src/main/kotlin/io/imotions/bson4k/common/BsonExceptions.kt
+++ b/src/main/kotlin/io/imotions/bson4k/common/BsonExceptions.kt
@@ -16,16 +16,19 @@
 
 package io.imotions.bson4k.common
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.descriptors.SerialDescriptor
 
 internal const val allowStructuredMapKeysHint =
-    "Use 'allowStructuredMapKeys = true' in 'Json {}' builder to convert such maps to [key1, value1, key2, value2,...] arrays."
+    "Use 'allowStructuredMapKeys = true' in 'Json {}' builder to convert such maps to " +
+        "[key1, value1, key2, value2,...] arrays."
 
 sealed class BsonException(message: String) : SerializationException(message)
 
 class BsonEncodingException(message: String) : BsonException(message)
 
+@OptIn(ExperimentalSerializationApi::class)
 fun invalidKeyKindException(keyDescriptor: SerialDescriptor) = BsonEncodingException(
     "Value of type '${keyDescriptor.serialName}' cannot be used as a BSON map key. " +
         "It should have either primitive or enum kind, but its kind is '${keyDescriptor.kind}'.\n" +

--- a/src/main/kotlin/io/imotions/bson4k/common/BsonExceptions.kt
+++ b/src/main/kotlin/io/imotions/bson4k/common/BsonExceptions.kt
@@ -28,9 +28,22 @@ sealed class BsonException(message: String) : SerializationException(message)
 
 class BsonEncodingException(message: String) : BsonException(message)
 
+class BsonDecodingException(message: String) : BsonException(message)
+
+fun rootNotDocumentException() = BsonEncodingException(
+    "BSON is a document format and serialization must be able to produce a document as the root structure for" +
+        "containing other types. Hence primitives and arrays cannot be serialized without an enclosing type."
+)
+
 @OptIn(ExperimentalSerializationApi::class)
 fun invalidKeyKindException(keyDescriptor: SerialDescriptor) = BsonEncodingException(
     "Value of type '${keyDescriptor.serialName}' cannot be used as a BSON map key. " +
         "It should have either primitive or enum kind, but its kind is '${keyDescriptor.kind}'.\n" +
         allowStructuredMapKeysHint
+)
+
+@OptIn(ExperimentalSerializationApi::class)
+fun missingClassDiscriminatorException(expectedDiscriminator: String, descriptor: SerialDescriptor) = BsonDecodingException(
+    "The expected class discriminator '$expectedDiscriminator', was not found when decoding the " +
+        "polymorphic type '${descriptor.serialName}'."
 )

--- a/src/test/kotlin/io/imotions/bson4k/decoder/BsonCollectionDecoderTest.kt
+++ b/src/test/kotlin/io/imotions/bson4k/decoder/BsonCollectionDecoderTest.kt
@@ -64,7 +64,9 @@ class BsonCollectionDecoderTest : StringSpec({
         println(document.toJson())
 
         val wrapper =
-            bson.decodeFromBsonDocument<CollectionWrapper<CollectionWrapper<Wrapper<String>>>>(document.toBsonDocument())
+            bson.decodeFromBsonDocument<CollectionWrapper<CollectionWrapper<Wrapper<String>>>>(
+                document.toBsonDocument()
+            )
         val inner = CollectionWrapper(list.map { Wrapper(it.toString()) })
         wrapper shouldBe CollectionWrapper(listOf(inner, inner))
     }

--- a/src/test/kotlin/io/imotions/bson4k/decoder/BsonMapDecoderTest.kt
+++ b/src/test/kotlin/io/imotions/bson4k/decoder/BsonMapDecoderTest.kt
@@ -23,6 +23,7 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
 import org.bson.BsonBinary
 import org.bson.Document
 import org.bson.UuidRepresentation
@@ -104,6 +105,32 @@ class BsonMapDecoderTest : StringSpec({
             MapSerializer(
                 UUIDSerializer,
                 StringUUIDContainer.serializer()
+            ),
+            doc.toBsonDocument()
+        )
+    }
+
+    "Decode to map with composite (structured) keys" {
+        val structuredBson = Bson {
+            allowStructuredMapKeys = true
+        }
+        val doc = Document(
+            "value",
+            listOf(
+                Document("x", "foo").append("y", "bar"),
+                0L,
+                Document("x", "hello").append("y", "world"),
+                10_000_000L
+            )
+        )
+            .also { println(it.toJson()) }
+
+        structuredBson.decodeFromBsonDocument(
+            Wrapper.serializer(
+                MapSerializer(
+                    Wrapper2.serializer(String.serializer(), String.serializer()),
+                    Long.serializer()
+                )
             ),
             doc.toBsonDocument()
         )

--- a/src/test/kotlin/io/imotions/bson4k/encoder/BsonMapEncoderTest.kt
+++ b/src/test/kotlin/io/imotions/bson4k/encoder/BsonMapEncoderTest.kt
@@ -19,6 +19,7 @@ package io.imotions.bson4k.encoder
 import io.imotions.bson4k.Bson
 import io.imotions.bson4k.BsonKind
 import io.imotions.bson4k.common.*
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.property.checkAll
@@ -80,5 +81,27 @@ class BsonMapEncoderTest : StringSpec({
             .also { println(it) }
 
         doc.keys shouldContainAll map.keys.map { it.toString() }
+    }
+
+    "Encode map with composite keys" {
+        val structuredBson = Bson {
+            allowStructuredMapKeys = true
+        }
+        val map = mapOf(
+            Wrapper2("foo", "bar") to 0L,
+            Wrapper2("hello", "world") to 10_000_000L
+        )
+        val wrapper = Wrapper(map)
+        val doc = structuredBson.encodeToBsonDocument(wrapper)
+            .also { println(it) }
+    }
+
+    "Encode map with composite key throws BsonEncodingException without allowedStructuredMapKeys" {
+        val map = mapOf(
+            Wrapper2("foo", "bar") to 0L,
+            Wrapper2("hello", "world") to 10_000_000L
+        )
+        val wrapper = Wrapper(map)
+        shouldThrow<BsonEncodingException> { bson.encodeToBsonDocument(wrapper) }
     }
 })

--- a/src/test/kotlin/io/imotions/bson4k/encoder/BsonMapEncoderTest.kt
+++ b/src/test/kotlin/io/imotions/bson4k/encoder/BsonMapEncoderTest.kt
@@ -22,10 +22,12 @@ import io.imotions.bson4k.common.*
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.shouldBe
 import io.kotest.property.checkAll
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.builtins.MapSerializer
 import org.bson.BsonInt32
+import org.bson.BsonType
 import java.util.*
 
 @ExperimentalSerializationApi
@@ -94,6 +96,14 @@ class BsonMapEncoderTest : StringSpec({
         val wrapper = Wrapper(map)
         val doc = structuredBson.encodeToBsonDocument(wrapper)
             .also { println(it) }
+
+        doc.getArray("value").forEachIndexed { index, bsonValue ->
+            bsonValue.bsonType shouldBe if (index % 2 == 0) {
+                BsonType.DOCUMENT
+            } else {
+                BsonType.INT64
+            }
+        }
     }
 
     "Encode map with composite key throws BsonEncodingException without allowedStructuredMapKeys" {


### PR DESCRIPTION
Closes #3 

Support for using structured map keys using arrays - `[k0, v0...kn, vn]` - since maps otherwise only can be represented in BSON as documents with primitive keys as strings. This is a very useful feature if you want to use complex key types in maps.

Support is optional and set via the configuration option `allowStructuredMapKeys` in the builder. It defaults to `false`