### PR TITLE
Encode defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,16 +53,18 @@ val bson = Bson {
     addTypeMapping(MyUUIDSerializer, BsonKind.UUID) // Add a type mapping. Can be called multiple times.
     allowStructuredMapKeys = true // Enable serialization of complex map keys using arrays ([k, v...kn, vn])
     implicitIntegerConversion = false // Disable attempt to implicitly convert integer kinds
+    encodeDefaults = true // Always encode default values
 }
 ```
 
-| Configuration parameter     | Optional | Default  | Accepted input                                     |
-|-----------------------------| -------- | -------- | -------------------------------------------------- |
-| `serializersModule`         | yes      | None     | T : SerializersModule                              |
-| `classDiscriminator`        | yes      | "__type" | String (avoid leading reserved bson chars like `$` |
-| `addTypeMapping`            | yes      | None.    | `addTypeMapping(Serializer, BsonKind)`             |
-| `allowStructuredMapKeys`    | yes      | `false`  | Boolean                                            |
-| `implicitIntegerConversion` | yes   | `true`   | Boolean                                            |
+| Configuration parameter     | Optional | Default   | Accepted input                                     |
+|-----------------------------|----------|-----------|----------------------------------------------------|
+| `serializersModule`         | yes      | None      | T : SerializersModule                              |
+| `classDiscriminator`        | yes      | "__type"  | String (avoid leading reserved bson chars like `$` |
+| `addTypeMapping`            | yes      | None.     | `addTypeMapping(Serializer, BsonKind)`             |
+| `allowStructuredMapKeys`    | yes      | `false`   | Boolean                                            |
+| `implicitIntegerConversion` | yes      | `true`    | Boolean                                            |
+| `encodeDefaults`            | yes      | `false`   | Boolean                                            |
 
 ### Serialization
 

--- a/src/main/kotlin/io/imotions/bson4k/Bson.kt
+++ b/src/main/kotlin/io/imotions/bson4k/Bson.kt
@@ -69,6 +69,7 @@ class BsonBuilder internal constructor(conf: BsonConf) {
     var serializersModule = conf.serializersModule
     var allowStructuredMapKeys = conf.allowStructuredMapKeys
     var implicitIntegerConversion = conf.implicitIntegerConversion
+    var encodeDefaults = conf.encodeDefaults
     internal val bsonTypeMappings = conf.bsonTypeMappings.toMutableMap()
 
     fun addTypeMapping(serializer: KSerializer<*>, bsonKind: BsonKind) {
@@ -87,7 +88,8 @@ class BsonBuilder internal constructor(conf: BsonConf) {
             serializersModule = serializersModule,
             bsonTypeMappings = bsonTypeMappings,
             allowStructuredMapKeys = allowStructuredMapKeys,
-            implicitIntegerConversion = implicitIntegerConversion
+            implicitIntegerConversion = implicitIntegerConversion,
+            encodeDefaults = encodeDefaults
         )
     }
 }

--- a/src/main/kotlin/io/imotions/bson4k/BsonConf.kt
+++ b/src/main/kotlin/io/imotions/bson4k/BsonConf.kt
@@ -30,5 +30,6 @@ data class BsonConf internal constructor(
     val classDiscriminator: String = CLASS_DISCRIMINATOR,
     val bsonTypeMappings: Map<SerialName, BsonKind> = emptyMap(),
     val allowStructuredMapKeys: Boolean = false,
-    val implicitIntegerConversion: Boolean = true
+    val implicitIntegerConversion: Boolean = true,
+    val encodeDefaults: Boolean = false
 )

--- a/src/main/kotlin/io/imotions/bson4k/encoder/BsonEncoder.kt
+++ b/src/main/kotlin/io/imotions/bson4k/encoder/BsonEncoder.kt
@@ -51,6 +51,9 @@ class BsonEncoder(
             return writer.document
         }
 
+    override fun shouldEncodeElementDefault(descriptor: SerialDescriptor, index: Int): Boolean =
+        conf.encodeDefaults
+
     override fun beginStructure(descriptor: SerialDescriptor): CompositeEncoder {
         when (descriptor.kind) {
             StructureKind.CLASS -> when (state) {

--- a/src/test/kotlin/io/imotions/bson4k/BsonTest.kt
+++ b/src/test/kotlin/io/imotions/bson4k/BsonTest.kt
@@ -19,6 +19,7 @@ package io.imotions.bson4k
 import io.imotions.bson4k.common.*
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.modules.EmptySerializersModule
@@ -106,6 +107,17 @@ class BsonTest : StringSpec({
         val deserialized = mappingBson.decodeFromBsonDocument<StringNullableDateContainer>(doc)
 
         deserialized shouldBe clazz
+    }
+
+    "Encode and decode without serialized default values" {
+        val clazz = Wrapper2Null<Boolean, Boolean>(y = false)
+        val doc = bson.encodeToBsonDocument(clazz)
+
+        doc.keys shouldContainExactly listOf("y")
+
+        val deserialized = bson.decodeFromBsonDocument<Wrapper2Null<Boolean, Boolean>>(doc)
+
+        deserialized shouldBe Wrapper2Null(null, false)
     }
 
     "Adding an invalid type mapping in the builder should throw" {

--- a/src/test/kotlin/io/imotions/bson4k/encoder/BsonClassEncoderTest.kt
+++ b/src/test/kotlin/io/imotions/bson4k/encoder/BsonClassEncoderTest.kt
@@ -16,15 +16,26 @@
 
 package io.imotions.bson4k.encoder
 
+import io.imotions.bson4k.Bson
 import io.imotions.bson4k.common.*
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.ints.shouldBeExactly
 import io.kotest.matchers.shouldBe
 import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.Serializable
 import org.bson.BsonInt32
 import org.bson.BsonNull
 import org.bson.BsonString
+
+@Serializable
+private data class DataClassWithDefaults(
+    val s: String,
+    val b: Boolean = true,
+    val i: Int = 42
+)
 
 @ExperimentalSerializationApi
 class BsonClassEncoderTest : StringSpec({
@@ -89,11 +100,22 @@ class BsonClassEncoderTest : StringSpec({
     }
 
     "Encode class with default nullables" {
+        val encodeDefaultsBson = Bson {
+            encodeDefaults = true
+        }
         val clazz = Wrapper2Null<String, String>(y = "hello")
-        val document = bson.encodeToBsonDocument(clazz)
+        val document = encodeDefaultsBson.encodeToBsonDocument(clazz)
             .also { println(it) }
 
         document["x"] shouldBe BsonNull()
         document["y"] shouldBe BsonString("hello")
+    }
+
+    "Encode class without defaults" {
+        val clazz = DataClassWithDefaults("test")
+        val document = bson.encodeToBsonDocument(clazz)
+            .also { println(it) }
+
+        document.keys shouldContainExactly listOf("s")
     }
 })


### PR DESCRIPTION
Closes #5 

Support `encodeDefaults` configuration option. Default is `false` and default values will not be encoded. If set to true default values are always encoded.